### PR TITLE
Fix apk artifact in github action

### DIFF
--- a/.github/workflows/build_android.yaml
+++ b/.github/workflows/build_android.yaml
@@ -180,7 +180,8 @@ jobs:
           echo "apk_size=$APK_SIZE" >> $GITHUB_OUTPUT
           
           # Generate APK filename with version info
-          APK_FILENAME="ai-edge-gallery-debug-${{ steps.release_info.outputs.commit_sha }}.apk"
+          COMMIT_SHA="${{ steps.release_info.outputs.commit_sha }}"
+          APK_FILENAME="ai-edge-gallery-debug-${COMMIT_SHA}.apk"
           echo "apk_filename=$APK_FILENAME" >> $GITHUB_OUTPUT
       
       - name: Prepare APK for release
@@ -193,12 +194,26 @@ jobs:
           echo "Original APK path: $APK_PATH"
           echo "Target APK filename: $APK_FILENAME"
           
-          # Copy APK to a predictable location with the desired filename
-          cp "$APK_PATH" "./$APK_FILENAME"
+          # Copy APK to repository root with the desired filename
+          cp "$APK_PATH" "$GITHUB_WORKSPACE/$APK_FILENAME"
           
-          echo "APK copied to: ./$APK_FILENAME"
+          echo "APK copied to: $GITHUB_WORKSPACE/$APK_FILENAME"
           echo "Verifying APK file exists:"
-          ls -la "./$APK_FILENAME"
+          ls -la "$GITHUB_WORKSPACE/$APK_FILENAME"
+
+      - name: Verify APK for release
+        run: |
+          echo "=== Verifying APK before release ==="
+          echo "Working directory: $(pwd)"
+          echo "Repository root: $GITHUB_WORKSPACE"
+          APK_FILENAME="${{ steps.find_apk.outputs.apk_filename }}"
+          echo "Expected APK filename: $APK_FILENAME"
+          echo "Checking if APK exists at repository root:"
+          ls -la "$GITHUB_WORKSPACE/$APK_FILENAME" || echo "APK not found at repository root"
+          echo "All files in repository root:"
+          ls -la "$GITHUB_WORKSPACE/"
+          echo "All APK files in repository:"
+          find "$GITHUB_WORKSPACE" -name "*.apk" -type f || echo "No APK files found in repository"
 
       - name: Create Release and Upload APK
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Fix GitHub Action to correctly find and upload the APK during release.

The APK was not found by the `softprops/action-gh-release` action because of two issues: incorrect variable interpolation when generating the APK filename, and the APK being copied to the job's default working directory (`./Android/src`) instead of the repository root where the release action expects it. This PR corrects both issues and adds a verification step.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1462026-8588-4f1b-ad99-b6c1cf2f2c8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1462026-8588-4f1b-ad99-b6c1cf2f2c8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

